### PR TITLE
Enable delete via method override

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 // app.js
 const express = require('express');
 const bodyParser = require('body-parser');
+const methodOverride = require('method-override');
 const db = require('./db');
 
 const app = express();
@@ -11,6 +12,9 @@ app.set('view engine', 'ejs');
 
 // Middleware для чтения данных формы (urlencoded)
 app.use(bodyParser.urlencoded({ extended: true }));
+
+// Поддержка методов PUT и DELETE через параметр _method
+app.use(methodOverride('_method'));
 
 // Папка, в которой лежат статические файлы (css, картинки)
 app.use(express.static('public'));

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "body-parser": "^2.2.0",
     "ejs": "^3.1.10",
     "express": "^4.21.2",
+    "method-override": "^3.0.0",
     "sqlite3": "^5.1.7"
   }
 }

--- a/views/sessions/show.ejs
+++ b/views/sessions/show.ejs
@@ -39,7 +39,8 @@
       <p><a class="btn-edit" href="/sessions/<%= session.id %>/edit">Редактировать</a></p>
 
       <!-- Пример кнопки удаления (которую вы сказали, что сделали DELETE) -->
-      <form action="/sessions/<%= session.id %>/delete" method="DELETE" style="display:inline;">
+      <form action="/sessions/<%= session.id %>/delete" method="POST" style="display:inline;">
+        <input type="hidden" name="_method" value="DELETE" />
         <button class="btn-delete" type="submit">Удалить</button>
       </form>
       <p><a href="/sessions">Вернуться к списку</a></p>


### PR DESCRIPTION
## Summary
- install `method-override`
- enable method overriding middleware
- update delete form to send POST with hidden `_method`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68553b3b02c4832c929c00c19429d4ff