### PR TITLE
Add user table and foreign key

### DIFF
--- a/db.js
+++ b/db.js
@@ -6,20 +6,41 @@ const path = require('path');
 const dbPath = path.join(__dirname, 'hypnodiary.db');
 const db = new sqlite3.Database(dbPath);
 
-// Создаём таблицу, если её нет
+// Создаём таблицы, если их нет
 db.serialize(() => {
+  // Таблица пользователей
+  db.run(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      username TEXT UNIQUE,
+      password_hash TEXT
+    );
+  `);
+
+  // Таблица сессий
   db.run(`
     CREATE TABLE IF NOT EXISTS sessions (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER,
       date TEXT,
       surname TEXT,
       name TEXT,
       sessionType TEXT,      -- "Я провёл" или "Мне провели"
       therapyLink TEXT,
       feedbackLink TEXT,
-      notes TEXT
+      notes TEXT,
+      FOREIGN KEY(user_id) REFERENCES users(id)
     );
   `);
+
+  // Если таблица sessions уже существовала, убедимся, что есть колонка user_id
+  db.all('PRAGMA table_info(sessions);', (err, columns) => {
+    if (err) return;
+    const hasUserId = columns.some(col => col.name === 'user_id');
+    if (!hasUserId) {
+      db.run('ALTER TABLE sessions ADD COLUMN user_id INTEGER;');
+    }
+  });
 });
 
 module.exports = db;


### PR DESCRIPTION
## Summary
- add `users` table in `db.js`
- include a `user_id` foreign key in `sessions`
- run ALTER TABLE if the `user_id` column doesn't exist

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68553dd94a80832c98e4ed0636408176