### PR TITLE
Add authentication with session store

### DIFF
--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Вход</title>
+    <link rel="stylesheet" href="/css/style.css" />
+  </head>
+  <body>
+    <div class="container">
+      <h1>Вход</h1>
+      <form action="/login" method="POST">
+        <label>Логин:</label><br />
+        <input type="text" name="username" /> <br />
+        <label>Пароль:</label><br />
+        <input type="password" name="password" /> <br />
+        <button type="submit">Войти</button>
+      </form>
+      <p><a href="/register">Регистрация</a></p>
+    </div>
+  </body>
+</html>

--- a/views/register.ejs
+++ b/views/register.ejs
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Регистрация</title>
+    <link rel="stylesheet" href="/css/style.css" />
+  </head>
+  <body>
+    <div class="container">
+      <h1>Регистрация</h1>
+      <form action="/register" method="POST">
+        <label>Логин:</label><br />
+        <input type="text" name="username" /> <br />
+        <label>Пароль:</label><br />
+        <input type="password" name="password" /> <br />
+        <button type="submit">Зарегистрироваться</button>
+      </form>
+      <p><a href="/login">Войти</a></p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- initialize express-session with connect-sqlite3
- add register, login and logout routes
- add auth middleware to protect `/sessions*`
- associate sessions with current user in DB
- create simple login and registration views

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68553eb3d9b8832ca097b927d8943480