### PR TITLE
Add auth views directory and login/logout links

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,6 +32,12 @@ app.use(
   })
 );
 
+// Делаем информацию об авторизации доступной во всех шаблонах
+app.use((req, res, next) => {
+  res.locals.isAuthenticated = !!req.session.userId;
+  next();
+});
+
 // Middleware проверки авторизации
 function requireAuth(req, res, next) {
   if (!req.session.userId) {
@@ -45,7 +51,7 @@ app.use('/sessions', requireAuth);
 
 // Страница регистрации
 app.get('/register', (req, res) => {
-  res.render('register');
+  res.render('auth/register');
 });
 
 app.post('/register', (req, res) => {
@@ -66,7 +72,7 @@ app.post('/register', (req, res) => {
 
 // Страница входа
 app.get('/login', (req, res) => {
-  res.render('login');
+  res.render('auth/login');
 });
 
 app.post('/login', (req, res) => {

--- a/views/auth/login.ejs
+++ b/views/auth/login.ejs
@@ -7,6 +7,16 @@
   </head>
   <body>
     <div class="container">
+      <p>
+        <% if (isAuthenticated) { %>
+          <form action="/logout" method="POST" style="display:inline;">
+            <button type="submit">Выйти</button>
+          </form>
+        <% } else { %>
+          <a href="/login">Войти</a> |
+          <a href="/register">Регистрация</a>
+        <% } %>
+      </p>
       <h1>Вход</h1>
       <form action="/login" method="POST">
         <label>Логин:</label><br />

--- a/views/auth/register.ejs
+++ b/views/auth/register.ejs
@@ -7,6 +7,16 @@
   </head>
   <body>
     <div class="container">
+      <p>
+        <% if (isAuthenticated) { %>
+          <form action="/logout" method="POST" style="display:inline;">
+            <button type="submit">Выйти</button>
+          </form>
+        <% } else { %>
+          <a href="/login">Войти</a> |
+          <a href="/register">Регистрация</a>
+        <% } %>
+      </p>
       <h1>Регистрация</h1>
       <form action="/register" method="POST">
         <label>Логин:</label><br />

--- a/views/sessions/edit.ejs
+++ b/views/sessions/edit.ejs
@@ -7,6 +7,16 @@
   </head>
   <body>
     <div class="container">
+      <p>
+        <% if (isAuthenticated) { %>
+          <form action="/logout" method="POST" style="display:inline;">
+            <button type="submit">Выйти</button>
+          </form>
+        <% } else { %>
+          <a href="/login">Войти</a> |
+          <a href="/register">Регистрация</a>
+        <% } %>
+      </p>
       <h1>Редактировать сеанс #<%= session.id %></h1>
       <form action="/sessions/<%= session.id %>/update" method="POST">
 

--- a/views/sessions/list.ejs
+++ b/views/sessions/list.ejs
@@ -88,6 +88,16 @@
   </head>
   <body>
     <div class="container">
+      <p>
+        <% if (isAuthenticated) { %>
+          <form action="/logout" method="POST" style="display:inline;">
+            <button type="submit">Выйти</button>
+          </form>
+        <% } else { %>
+          <a href="/login">Войти</a> |
+          <a href="/register">Регистрация</a>
+        <% } %>
+      </p>
       <h1>📒 Список сеансов</h1>
 
       <div class="stats-box">

--- a/views/sessions/new.ejs
+++ b/views/sessions/new.ejs
@@ -7,6 +7,16 @@
   </head>
   <body>
     <div class="container">
+      <p>
+        <% if (isAuthenticated) { %>
+          <form action="/logout" method="POST" style="display:inline;">
+            <button type="submit">Выйти</button>
+          </form>
+        <% } else { %>
+          <a href="/login">Войти</a> |
+          <a href="/register">Регистрация</a>
+        <% } %>
+      </p>
       <h1>Добавить сеанс</h1>
       <form action="/sessions" method="POST">
         <label>Дата:</label><br />

--- a/views/sessions/show.ejs
+++ b/views/sessions/show.ejs
@@ -7,6 +7,16 @@
   </head>
   <body>
     <div class="container">
+      <p>
+        <% if (isAuthenticated) { %>
+          <form action="/logout" method="POST" style="display:inline;">
+            <button type="submit">Выйти</button>
+          </form>
+        <% } else { %>
+          <a href="/login">Войти</a> |
+          <a href="/register">Регистрация</a>
+        <% } %>
+      </p>
       <h1>Сеанс <%= session.id %></h1>
       <p>Дата: <%= session.date %></p>
       <p>Фамилия: <%= session.surname %></p>


### PR DESCRIPTION
## Summary
- move login/register views into `views/auth`
- expose `isAuthenticated` for templates
- show login/logout links on session pages

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node app.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68553fe7a4e4832c9f350f50e90b7aa8