### PR TITLE
Switch session deletion to DELETE

### DIFF
--- a/app.js
+++ b/app.js
@@ -204,8 +204,8 @@ function transformYouTubeLink(link) {
   return link;
 }
 // Удаление конкретного сеанса
-// Используем POST, так как HTML формы не поддерживают DELETE
-app.post('/sessions/:id/delete', async (req, res) => {
+// Форма отправляет POST c _method=DELETE, method-override преобразует его в DELETE
+app.delete('/sessions/:id/delete', async (req, res) => {
   const sessionId = req.params.id;
 
   try {


### PR DESCRIPTION
## Summary
- use HTTP DELETE for deleting sessions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68556291ad50832cbd05ed6a29b7880f