### PR TITLE
Add start script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cp .env.example .env
 ### 4. Запустить приложение
 
 ```bash
-node app.js
+npm start
 ```
 
 Перед запуском убедитесь, что в `.env` указан `DATABASE_URL` с данными PostgreSQL

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node app.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add npm start script to package.json
- document using `npm start` in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855632089b8832ca8343ca25e2aa05d