### PR TITLE
Add session table creation for connect-pg-simple

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,7 +26,10 @@ app.use(express.static('public'));
 const sessionSecret = process.env.SESSION_SECRET || 'keyboard cat';
 app.use(
   session({
-    store: new PgStore({ pool: db }),
+    store: new PgStore({
+      pool: db,
+      createTableIfMissing: true
+    }),
     secret: sessionSecret,
     resave: false,
     saveUninitialized: false

--- a/db.js
+++ b/db.js
@@ -31,6 +31,18 @@ async function init() {
       notes TEXT
     );
   `);
+
+  // Table used by connect-pg-simple for storing express sessions
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS session (
+      sid varchar PRIMARY KEY,
+      sess json NOT NULL,
+      expire timestamp(6) NOT NULL
+    );
+  `);
+  await pool.query(
+    'CREATE INDEX IF NOT EXISTS "IDX_session_expire" ON session("expire")'
+  );
 }
 
 init().catch(err => console.error('DB init error:', err));


### PR DESCRIPTION
## Summary
- ensure database has `session` table used by `connect-pg-simple`
- configure the session store to create the table automatically on start

## Testing
- `npm install`
- `node app.js`

------
https://chatgpt.com/codex/tasks/task_e_68556a6f8304832c8b1754df277e208e